### PR TITLE
Update OAPMessage.py

### DIFF
--- a/SmartMeshSDK/protocols/oap/OAPMessage.py
+++ b/SmartMeshSDK/protocols/oap/OAPMessage.py
@@ -147,6 +147,13 @@ class Sensor(object):
         self.sample_count    = TLVByte(2)
         self.data_format     = TLVByte(3)
         self.value           = TLVShort(4)
+        
+        if(self.addr[0]==2):
+            self.sample_count    = TLVShort(2) #As the notifications from digital channels generate 2 bytes for sample count
+            self.value           = TLVByte(4)  #and one byte for value
+                                               #If this change is not made OAPMessage.TLV.parse_value(val_str) fails to parse 
+                                               #the value tag () as it runs out of bounds.
+        
         self.tags            = [ self.enable,
                                  self.rate,
                                  self.sample_count,


### PR DESCRIPTION
There is a problem with the initialization of self.value as a TLVShort and self.sample_count as a TLVByte for digital channels in the Sensor class. The digital channels send 2 bytes for sample count and 1 byte for value that is why OAPMessage.TLV.parse_value(val_str) fails to parse the value tag () as it runs out of bounds.