### PR TITLE
fix cli arguments type casting

### DIFF
--- a/app/JsonServer/JsonServer.py
+++ b/app/JsonServer/JsonServer.py
@@ -478,9 +478,9 @@ def main(args):
 
 if __name__=="__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--tcpport',        default=8080)
-    parser.add_argument('--autoaddmgr',     default=True)
-    parser.add_argument('--autodeletemgr',  default=True)
+    parser.add_argument('--tcpport', type=int, default=8080)
+    parser.add_argument('--autoaddmgr', action='store_false', help='to disable autoaddmgr thread', default=True)
+    parser.add_argument('--autodeletemgr', action='store_false', help='to disable autodeletemgr thread', default=True)
     parser.add_argument('--serialport',     default=None)
     parser.add_argument('--configfilename', default='JsonServer.config')
     args = vars(parser.parse_args())


### PR DESCRIPTION
## Fix CLI arguments type casting

The JsonServer is designed to allow change the tcpport and disable autoaddmgr and autodeletemgr settings via command line arguments `--tcpport 8081`, `--autoaddmgr False` and `--autodeltemgr False`.

### description of the bug
The current code does not works as per design intention as the python `argparse` library consider the default user input as ‘string’,

User input:

    python JsonServer.py --tcpport 8081

will parsed by the argparse as a string instead of an integer for 8081:

    {'serialport': None, 'autodeletemgr': False, 'configfilename': 'JsonServer.config', 'autoaddmgr': True, 'tcpport': '8081'}

Same issue for `--autoaddmgr`(and `--autodeletemgr`), where the user input argument is parsed as a string instead of bool.

    python JsonServer.py --autoaddmgr False

result:

    {'serialport': None, 'autodeletemgr': False, 'configfilename': 'JsonServer.config', 'autoaddmgr': 'False', 'tcpport': 8080}

### proposed changes for fixing the issue
The solution for correctly cast the input argument for `--tcpport` can be solved by add `type=int` into the code:

    parser.add_argument('--tcpport', type=int, default=8080)

Adding `type=bool` however doesn’t work for `argparse` library, instead it requires of using `action` as suggested by `argparse` documentation (see reference link below):

    parse.add_argument(‘--autoaddmgr’, action=“store_false’, help='to disable autoaddmgr thread', default=True)

With `action='store-false`, simply add `--autoaddmgr` as command line argument without a value will disable the autoaddmgr thread. This is a little bit counter-intuitive, therefore a helper text would be helpful to explain the usage.

    python JsonServer.py --autoaddmgr

Reference: https://docs.python.org/2.7/library/argparse.html#action
