### PR TITLE
fix high cpu utilzation when autoaddmgr is running on JsonServer

### DIFF
--- a/libs/SmartMeshSDK/utils/SerialScanner.py
+++ b/libs/SmartMeshSDK/utils/SerialScanner.py
@@ -165,6 +165,7 @@ class SerialScanner(object):
                 self.goOn = False
                 serialHandler.close()
                 while listenThread.isAlive():
+                    time.sleep(0.01)
                     pass # wait for listenThread to stop
             except serial.SerialException:
                 pass # happens when serial port unavailable


### PR DESCRIPTION
## Fix high cpu utilization

The JsonServer is experiencing high cpu utilzation of above 90% when autoaddmgr thread is enabled even when IP manager is idel without any activities from motes.

### Description of the issue
Further investigation leads to this part of the code at smartmeshsdk/libs/SmartMeshSDK/utils/SerialScanner.py:

    while listenThread.isAlive():
        pass # wait for listenThread to stop

The code is looping in a NON-BLOCKING manner, and therefore keep the CPU busy at all time.

### Proposed changes for fixing the issue
To introduce a delay (blocking) into the loop. My test shows that by adding merely 0.01s sleep into the while loop will bring the cpu utilization from 90+% down to about 3.5% running on a beaglebone black host.

I'm proposing to add 0.1s delay into the loop:

    while listenThread.isAlive():
        time.sleep(0.01)
        pass # wait for listenThread to stop
